### PR TITLE
Require SQLite watchlist configuration and update docs

### DIFF
--- a/DayTrading/.env.example
+++ b/DayTrading/.env.example
@@ -4,8 +4,7 @@ TZ=America/Toronto
 SIMULATION=true
 
 # Watchlist ingestion
-WATCHLIST_FILE=./incoming/full_watchlist.json
-WATCHLIST_GLOB=./incoming/full_watchlist*.json
+WATCHLIST_DB_PATH=/path/to/premarket.db
 WATCHLIST_SYMBOL_KEY=symbol
 
 # Storage

--- a/DayTrading/README.md
+++ b/DayTrading/README.md
@@ -48,8 +48,9 @@ poetry run python main.py
 
 ### Watchlist Ingestion
 
-Drop your daily JSON file (matching the schema in `samples/watchlist_minimal.json`) and point the
-`WATCHLIST_FILE` environment variable at it. You can manually import the file with:
+Point `WATCHLIST_DB_PATH` at the shared pre-market SQLite database and the engine will pull the
+latest symbols directly. If you receive a JSON export instead, you can manually import it into the
+engine's SQLite store with:
 
 ```bash
 poetry run python scripts/import_watchlist.py --path ./incoming/full_watchlist.json
@@ -72,8 +73,9 @@ poetry run black --check .
 
 ### Troubleshooting
 
-- **Missing watchlist file** – Ensure `WATCHLIST_FILE` points to a readable JSON file or provide a
-  fallback glob via `WATCHLIST_GLOB`.
+- **Missing watchlist data** – Ensure `WATCHLIST_DB_PATH` points to the shared SQLite database. If
+  you're importing JSON manually, run `scripts/import_watchlist.py` first so the latest symbols are
+  present in the local store.
 - **Empty symbols** – The loader requires a non-empty string `symbol`. Duplicate symbols are
   deduplicated with a log entry.
 - **DB permissions** – The SQLite file is created at `SQLITE_PATH`; ensure the directory exists and

--- a/DayTrading/intraday/ingestion/watchlist_loader.py
+++ b/DayTrading/intraday/ingestion/watchlist_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -51,9 +52,27 @@ class WatchlistLoader:
         self.settings = settings
         self.db = db
 
-    def load(self, path: Path | None = None) -> tuple[int, list[str], Dict[str, Dict[str, object]]]:
-        watchlist_path = path or self.settings.watchlist_path()
-        payload = json.loads(watchlist_path.read_text(encoding="utf-8"))
+    def load(
+        self, path: Path | None = None
+    ) -> tuple[int, list[str], Dict[str, Dict[str, object]]]:
+        if path is not None:
+            return self._load_from_json(path)
+
+        db_path = self.settings.watchlist_db_path
+        if not db_path:
+            raise ValueError(
+                "WATCHLIST_DB_PATH must be configured when no explicit watchlist path is provided"
+            )
+
+        candidate = Path(db_path)
+        if not candidate.exists():
+            raise FileNotFoundError(f"Watchlist database not found: {candidate}")
+        return self._load_from_sqlite(candidate)
+
+    def _load_from_json(
+        self, path: Path
+    ) -> tuple[int, list[str], Dict[str, Dict[str, object]]]:
+        payload = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(payload, list):
             raise ValueError("Watchlist JSON must be a list")
 
@@ -63,8 +82,8 @@ class WatchlistLoader:
         for raw in payload:
             if not isinstance(raw, dict):
                 continue
-            normalized = {k.lower(): v for k, v in raw.items()}
             symbol_key = self.settings.watchlist_symbol_key.lower()
+            normalized = {k.lower(): v for k, v in raw.items()}
             symbol = normalized.get(symbol_key)
             if not isinstance(symbol, str) or not symbol:
                 logger.warning("Skipping entry missing symbol: %s", raw)
@@ -74,22 +93,191 @@ class WatchlistLoader:
                 logger.info("Duplicate symbol %s detected; keeping first entry", symbol)
                 continue
             deduped[symbol] = raw
+            flat_map[symbol] = self._build_flat_context(normalized)
 
-            flat_context: Dict[str, object] = {}
-            for key in _FLAT_FIELDS:
-                if key in normalized:
-                    flat_context[key] = normalized[key]
-            features = normalized.get("features")
-            if isinstance(features, dict):
-                for key in _FEATURE_FIELDS:
-                    if key in features:
-                        flat_context[key] = features[key]
-            flat_map[symbol] = flat_context
+        return self._persist_run(str(path), deduped, flat_map)
 
+    def _load_from_sqlite(
+        self, db_path: Path
+    ) -> tuple[int, list[str], Dict[str, Dict[str, object]]]:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            latest_watchlist = conn.execute(
+                "SELECT run_date, generated_at FROM watchlist ORDER BY generated_at DESC LIMIT 1"
+            ).fetchone()
+            latest_full = conn.execute(
+                "SELECT run_date, generated_at FROM full_watchlist ORDER BY generated_at DESC LIMIT 1"
+            ).fetchone()
+
+            if latest_watchlist is None and latest_full is None:
+                raise ValueError("No watchlist data found in database")
+
+            run_date = (latest_watchlist or latest_full)["run_date"]
+            generated_at = (latest_watchlist or latest_full)["generated_at"]
+
+            watch_rows = conn.execute(
+                """
+                SELECT *
+                FROM watchlist
+                WHERE run_date = ? AND generated_at = ?
+                ORDER BY COALESCE(rank, 1e9), symbol
+                """,
+                (run_date, generated_at),
+            ).fetchall()
+
+            watch_map: Dict[str, sqlite3.Row] = {}
+            symbol_order: List[str] = []
+            for row in watch_rows:
+                symbol = row["symbol"]
+                if not symbol:
+                    continue
+                symbol = symbol.upper()
+                if symbol not in symbol_order:
+                    symbol_order.append(symbol)
+                watch_map[symbol] = row
+
+            full_generated_at = generated_at
+            if latest_full is not None:
+                full_generated_at = latest_full["generated_at"]
+
+            full_rows = conn.execute(
+                """
+                SELECT *
+                FROM full_watchlist
+                WHERE run_date = ? AND generated_at = ?
+                """,
+                (run_date, full_generated_at),
+            ).fetchall()
+
+            if not full_rows and latest_full is not None:
+                full_rows = conn.execute(
+                    "SELECT * FROM full_watchlist WHERE run_date = ? ORDER BY generated_at DESC",
+                    (run_date,),
+                ).fetchall()
+
+            full_map: Dict[str, dict] = {}
+            for row in full_rows:
+                symbol = row["symbol"]
+                if not symbol:
+                    continue
+                symbol = symbol.upper()
+                full_map[symbol] = self._row_to_payload(
+                    row,
+                    {
+                        "features_json": "features",
+                        "tags_json": "tags",
+                        "rejection_reasons_json": "rejection_reasons",
+                    },
+                )
+
+            if not symbol_order:
+                scored_symbols: List[tuple[float, str]] = []
+                for symbol, payload in full_map.items():
+                    score = payload.get("score")
+                    try:
+                        score_value = float(score)
+                    except (TypeError, ValueError):
+                        score_value = float("-inf")
+                    scored_symbols.append((score_value, symbol))
+                scored_symbols.sort(key=lambda item: (-item[0], item[1]))
+                symbol_order = [symbol for _, symbol in scored_symbols]
+                if not symbol_order:
+                    symbol_order = sorted(full_map.keys())
+
+            remaining_symbols = [
+                symbol for symbol in full_map.keys() if symbol not in symbol_order
+            ]
+            if remaining_symbols:
+                scored_remaining: List[tuple[float, str]] = []
+                for symbol in remaining_symbols:
+                    score = full_map[symbol].get("score")
+                    try:
+                        score_value = float(score)
+                    except (TypeError, ValueError):
+                        score_value = float("-inf")
+                    scored_remaining.append((score_value, symbol))
+                scored_remaining.sort(key=lambda item: (-item[0], item[1]))
+                symbol_order.extend(symbol for _, symbol in scored_remaining)
+
+            deduped: "OrderedDict[str, dict]" = OrderedDict()
+            flat_map: Dict[str, Dict[str, object]] = {}
+
+            for symbol in symbol_order:
+                payload: dict = {}
+                if symbol in full_map:
+                    payload.update(full_map[symbol])
+                if symbol in watch_map:
+                    payload.update(
+                        self._row_to_payload(
+                            watch_map[symbol],
+                            {
+                                "tags_json": "tags",
+                            },
+                        )
+                    )
+                payload.setdefault("symbol", symbol)
+                deduped[symbol] = payload
+                flat_map[symbol] = self._build_flat_context(
+                    {k.lower(): v for k, v in payload.items()}
+                )
+
+            return self._persist_run(str(db_path), deduped, flat_map)
+        finally:
+            conn.close()
+
+    def _row_to_payload(self, row: sqlite3.Row, json_fields: Dict[str, str]) -> dict:
+        payload: dict = {}
+        for key in row.keys():
+            alias = json_fields.get(key)
+            value = row[key]
+            if alias:
+                parsed = self._parse_json_field(value)
+                if parsed is not None:
+                    payload[alias] = parsed
+            else:
+                payload[key] = value
+        return payload
+
+    def _build_flat_context(self, normalized: Dict[str, object]) -> Dict[str, object]:
+        flat_context: Dict[str, object] = {}
+        for key in _FLAT_FIELDS:
+            if key in normalized:
+                flat_context[key] = normalized[key]
+        features = normalized.get("features")
+        if isinstance(features, dict):
+            for key in _FEATURE_FIELDS:
+                if key in features:
+                    flat_context[key] = features[key]
+        return flat_context
+
+    def _parse_json_field(self, value: str | None) -> object | None:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                logger.warning("Failed to decode JSON field: %s", value)
+                return text
+        return value
+
+    def _persist_run(
+        self,
+        source: str,
+        deduped: "OrderedDict[str, dict]",
+        flat_map: Dict[str, Dict[str, object]],
+    ) -> tuple[int, list[str], Dict[str, Dict[str, object]]]:
         run_ts = time_utils.to_epoch_seconds(time_utils.now_et())
-        run_id = self.db.insert_watchlist_run(run_ts, str(watchlist_path), len(deduped))
-        self.db.insert_watchlist_items(run_id, ((symbol, payload) for symbol, payload in deduped.items()))
-
+        run_id = self.db.insert_watchlist_run(run_ts, source, len(deduped))
+        self.db.insert_watchlist_items(
+            run_id, ((symbol, payload) for symbol, payload in deduped.items())
+        )
         return run_id, list(deduped.keys()), flat_map
 
 

--- a/DayTrading/intraday/settings.py
+++ b/DayTrading/intraday/settings.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import glob
 import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 
 from .utils.time import ET
 
@@ -17,8 +15,7 @@ class AppSettings:
     run_mode: str = "once"
     tz: str = "America/Toronto"
     simulation: bool = True
-    watchlist_file: str | None = None
-    watchlist_glob: str | None = None
+    watchlist_db_path: str | None = None
     watchlist_symbol_key: str = "symbol"
     sqlite_path: str = "var/daytrading.db"
     ema_fast: int = 9
@@ -53,8 +50,7 @@ class AppSettings:
 
         self.tz = env("TZ", self.tz)
         self.simulation = env("SIMULATION", str(self.simulation)).lower() == "true"
-        self.watchlist_file = env("WATCHLIST_FILE", self.watchlist_file)
-        self.watchlist_glob = env("WATCHLIST_GLOB", self.watchlist_glob)
+        self.watchlist_db_path = env("WATCHLIST_DB_PATH", self.watchlist_db_path)
         self.watchlist_symbol_key = env("WATCHLIST_SYMBOL_KEY", self.watchlist_symbol_key)
         self.sqlite_path = env("SQLITE_PATH", self.sqlite_path)
 
@@ -103,18 +99,6 @@ class AppSettings:
     def flatten_dt_today(self) -> datetime:
         hour, minute = map(int, self.flatten_et.split(":"))
         return datetime.now(tz=ET).replace(hour=hour, minute=minute, second=0, microsecond=0)
-
-    def watchlist_path(self) -> Path:
-        if self.watchlist_file:
-            candidate = Path(self.watchlist_file)
-            if candidate.exists():
-                return candidate
-        if self.watchlist_glob:
-            matches = sorted(glob.glob(self.watchlist_glob))
-            if matches:
-                return Path(matches[-1])
-        raise FileNotFoundError("No watchlist file found")
-
 
 def load_settings() -> AppSettings:
     return AppSettings()

--- a/DayTrading/tests/conftest.py
+++ b/DayTrading/tests/conftest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
+import sqlite3
 from pathlib import Path
 from typing import Iterator
 
@@ -14,14 +16,17 @@ from intraday.utils.env import load_environment
 
 @pytest.fixture(autouse=True)
 def _configure_env(tmp_path: Path) -> Iterator[None]:
+    premarket_db = tmp_path / "premarket.db"
+    _create_premarket_db(premarket_db)
+
     env_path = tmp_path / ".env"
     env_path.write_text(
         """
 RUN_MODE=once
 SIMULATION=true
-WATCHLIST_FILE=samples/watchlist_minimal.json
+WATCHLIST_DB_PATH={watchlist_db}
 SQLITE_PATH={db}
-""".strip().format(db=tmp_path / "test.db"),
+""".strip().format(watchlist_db=premarket_db, db=tmp_path / "test.db"),
         encoding="utf-8",
     )
     cwd = Path(__file__).resolve().parents[1]
@@ -47,3 +52,236 @@ def db(settings: AppSettings) -> Iterator[Database]:
 @pytest.fixture
 def orchestrator(settings: AppSettings, db: Database) -> Orchestrator:
     return Orchestrator(settings, db)
+
+
+def _create_premarket_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS full_watchlist (
+            run_date TEXT NOT NULL,
+            generated_at TEXT NOT NULL,
+            symbol TEXT,
+            company TEXT,
+            sector TEXT,
+            industry TEXT,
+            exchange TEXT,
+            market_cap TEXT,
+            pe TEXT,
+            price TEXT,
+            change_pct TEXT,
+            gap_pct TEXT,
+            volume TEXT,
+            avg_volume_3m TEXT,
+            rel_volume TEXT,
+            float_shares TEXT,
+            short_float_pct TEXT,
+            after_hours_change_pct TEXT,
+            week52_range TEXT,
+            week52_pos TEXT,
+            earnings_date TEXT,
+            analyst_recom TEXT,
+            features_json TEXT,
+            score TEXT,
+            tier TEXT,
+            tags_json TEXT,
+            rejection_reasons_json TEXT,
+            insider_transactions TEXT,
+            institutional_transactions TEXT
+        );
+        CREATE TABLE IF NOT EXISTS watchlist (
+            run_date TEXT NOT NULL,
+            generated_at TEXT NOT NULL,
+            rank INTEGER,
+            symbol TEXT,
+            score TEXT,
+            tier TEXT,
+            gap_pct TEXT,
+            rel_volume TEXT,
+            tags_json TEXT,
+            why TEXT,
+            top_feature1 TEXT,
+            top_feature2 TEXT,
+            top_feature3 TEXT,
+            top_feature4 TEXT,
+            top_feature5 TEXT
+        );
+        """
+    )
+
+    full_rows = [
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            "AAPL",
+            "Apple Inc.",
+            "Technology",
+            "Consumer Electronics",
+            "NASDAQ",
+            "2.8T",
+            "25.1",
+            "182.12",
+            "1.3",
+            "1.2",
+            "1000000",
+            "800000",
+            "1.5",
+            "16.0",
+            "0.20",
+            "0.15",
+            "120-198",
+            "0.72",
+            "2024-05-02",
+            "Buy",
+            json.dumps({"relvol": 1.5, "float_band": "mid", "short_float": 0.02}),
+            "9.1",
+            "A",
+            json.dumps(["tech", "momentum"]),
+            json.dumps([]),
+            "0",
+            "0",
+        ),
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            "MSFT",
+            "Microsoft Corp.",
+            "Technology",
+            "Software",
+            "NASDAQ",
+            "2.5T",
+            "30.4",
+            "310.50",
+            "0.5",
+            "0.4",
+            "900000",
+            "700000",
+            "1.1",
+            "12.0",
+            "0.18",
+            "0.05",
+            "220-345",
+            "0.65",
+            "2024-04-24",
+            "Hold",
+            json.dumps({"relvol": 1.1, "news_fresh": True}),
+            "8.5",
+            "B",
+            json.dumps(["software"]),
+            json.dumps([]),
+            "0",
+            "0",
+        ),
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            "TSLA",
+            "Tesla Inc.",
+            "Automotive",
+            "Auto Manufacturers",
+            "NASDAQ",
+            "800B",
+            "70.0",
+            "250.20",
+            "-0.8",
+            "-1.0",
+            "1500000",
+            "900000",
+            "2.2",
+            "20.0",
+            "0.25",
+            "-0.40",
+            "120-300",
+            "0.55",
+            "2024-04-17",
+            "Sell",
+            json.dumps({"relvol": 2.2, "after_hours": -0.5, "analyst": "downgrade"}),
+            "7.9",
+            "B",
+            json.dumps(["ev"]),
+            json.dumps([]),
+            "0",
+            "0",
+        ),
+    ]
+
+    watchlist_rows = [
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            1,
+            "AAPL",
+            "9.1",
+            "A",
+            "1.2",
+            "1.5",
+            json.dumps(["gap", "relative-volume"]),
+            "Strong premarket gap",
+            "Gap > 1%",
+            "High relvol",
+            "Float mid",
+            None,
+            None,
+        ),
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            2,
+            "MSFT",
+            "8.5",
+            "B",
+            "0.4",
+            "1.1",
+            json.dumps(["software"]),
+            "Steady continuation",
+            "Software strength",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "2024-04-01",
+            "2024-04-01T08:30:00Z",
+            3,
+            "TSLA",
+            "7.9",
+            "B",
+            "-1.0",
+            "2.2",
+            json.dumps(["ev"]),
+            "Watching after downgrade",
+            "Analyst downgrade",
+            "After hours dip",
+            None,
+            None,
+            None,
+        ),
+    ]
+
+    cur.executemany(
+        """
+        INSERT INTO full_watchlist (
+            run_date, generated_at, symbol, company, sector, industry, exchange,
+            market_cap, pe, price, change_pct, gap_pct, volume, avg_volume_3m, rel_volume,
+            float_shares, short_float_pct, after_hours_change_pct, week52_range, week52_pos,
+            earnings_date, analyst_recom, features_json, score, tier, tags_json,
+            rejection_reasons_json, insider_transactions, institutional_transactions
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        full_rows,
+    )
+
+    cur.executemany(
+        """
+        INSERT INTO watchlist (
+            run_date, generated_at, rank, symbol, score, tier, gap_pct, rel_volume,
+            tags_json, why, top_feature1, top_feature2, top_feature3, top_feature4, top_feature5
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        watchlist_rows,
+    )
+
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- require WATCHLIST_DB_PATH when loading the watchlist without an explicit override
- remove the legacy JSON fallback settings and update the documentation to reflect the SQLite workflow
- refresh the environment sample to document WATCHLIST_DB_PATH

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68df344b57f88331884d1f0e0d7c37ed