### PR TITLE
Integrate intraday engine with phase 2 schema

### DIFF
--- a/DayTrading/intraday/ai/sentiment.py
+++ b/DayTrading/intraday/ai/sentiment.py
@@ -51,12 +51,13 @@ class SentimentAnalyzer:
                 logger.warning("Failed to load FinBERT; falling back to heuristics: %s", exc)
                 self._pipeline = None
 
-    def analyze(self, news_items: Iterable[models.NewsItem]) -> Dict[str, SentimentResult]:
-        news_map: Dict[str, List[models.NewsItem]] = {}
+    def analyze(self, news_items: Iterable[models.Catalyst]) -> Dict[str, SentimentResult]:
+        news_map: Dict[str, List[models.Catalyst]] = {}
         for item in news_items:
             news_map.setdefault(item.symbol, []).append(item)
 
         results: Dict[str, SentimentResult] = {}
+        provenance: List[models.AIProvenanceRecord] = []
         for symbol, items in news_map.items():
             if not self.settings.ai_sentiment_enabled:
                 results[symbol] = SentimentResult(score=0.0, gate="PASS", reasons=["disabled"])
@@ -79,14 +80,16 @@ class SentimentAnalyzer:
                 reasons.append("neutral or positive")
 
             results[symbol] = SentimentResult(score=score, gate=gate, reasons=reasons)
-            self._persist(symbol, score, gate, reasons, items)
+            provenance.append(self._build_provenance(symbol, score, gate, reasons, items))
 
+        if provenance:
+            self.db.write_ai_provenance(provenance)
         return results
 
-    def _score_with_finbert(self, items: List[models.NewsItem]) -> float:
+    def _score_with_finbert(self, items: List[models.Catalyst]) -> float:
         # Simplified FinBERT scoring averaging logits (if available).
         tokenizer, model = self._pipeline  # type: ignore[misc]
-        texts = [item.headline for item in items if item.headline]
+        texts = [item.title for item in items if item.title]
         if not texts:
             return 0.0
         encoded = tokenizer(texts, padding=True, truncation=True, return_tensors="pt")  # type: ignore[operator]
@@ -98,11 +101,11 @@ class SentimentAnalyzer:
         scores = probs[:, 2] - probs[:, 0]
         return float(scores.mean().item())
 
-    def _score_with_heuristic(self, items: List[models.NewsItem]) -> float:
+    def _score_with_heuristic(self, items: List[models.Catalyst]) -> float:
         score = 0.0
         count = 0
         for item in items:
-            text = item.headline.lower()
+            text = item.title.lower()
             word_score = 0
             for token in _POSITIVE_LEXICON:
                 if token in text:
@@ -118,35 +121,23 @@ class SentimentAnalyzer:
         normalized = max(min(score / count, 3.0), -3.0) / 3.0
         return float(normalized)
 
-    def _persist(
+    def _build_provenance(
         self,
         symbol: str,
         score: float,
         gate: str,
         reasons: List[str],
-        items: List[models.NewsItem],
-    ) -> None:
-        payload = {
-            "symbol": symbol,
-            "run_ts": to_epoch_seconds(now_et()),
-            "raw_text": "\n".join(item.headline for item in items if item.headline),
-            "model": self.settings.ai_model,
-            "score": score,
-            "gate": gate,
-            "reasons": reasons,
-        }
-        self.db.execute(
-            "INSERT INTO ai_provenance(symbol, run_ts, raw_text, model, score, gate, reasons) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                payload["symbol"],
-                payload["run_ts"],
-                payload["raw_text"],
-                payload["model"],
-                payload["score"],
-                payload["gate"],
-                json.dumps(payload["reasons"]),
-            ),
+        items: List[models.Catalyst],
+    ) -> models.AIProvenanceRecord:
+        headlines = [item.title for item in items if item.title]
+        return models.AIProvenanceRecord(
+            symbol=symbol,
+            ts=to_epoch_seconds(now_et()),
+            model_name=self.settings.ai_model,
+            inputs={"headlines": headlines},
+            outputs={"score": score, "gate": gate, "reasons": reasons},
+            delta_applied=score,
+            notes="sentiment",
         )
 
 
-import json  # placed at bottom to avoid circular import during module load

--- a/DayTrading/intraday/data/catalysts.py
+++ b/DayTrading/intraday/data/catalysts.py
@@ -4,13 +4,12 @@ import logging
 from typing import Iterable, List, Tuple
 
 from ..storage import models
-from ..storage.db import Database
 from ..utils.time import hours_ago
 
 logger = logging.getLogger(__name__)
 
 
-def merge_catalysts(db: Database, freshness_hours: int, *sources: Iterable[dict]) -> List[models.NewsItem]:
+def merge_catalysts(freshness_hours: int, *sources: Iterable[dict]) -> List[models.Catalyst]:
     combined: dict[Tuple[str, str], dict] = {}
     for source_items in sources:
         for item in source_items:
@@ -27,24 +26,32 @@ def merge_catalysts(db: Database, freshness_hours: int, *sources: Iterable[dict]
                 combined[key] = payload
 
     threshold_ts = int(hours_ago(freshness_hours).timestamp())
-    news_items: List[models.NewsItem] = []
+    catalysts: List[models.Catalyst] = []
     for (_symbol, _headline), payload in combined.items():
         ts = int(payload.get("ts", 0))
         fresh = ts >= threshold_ts
-        meta = {k: v for k, v in payload.items() if k not in {"symbol", "headline", "url", "ts", "source"}}
-        meta["fresh"] = fresh
-        news_items.append(
-            models.NewsItem(
+        catalysts.append(
+            models.Catalyst(
                 symbol=payload["symbol"].upper(),
-                source=str(payload.get("source", "unknown")),
-                headline=str(payload.get("headline", "")),
-                url=str(payload.get("url", "")),
                 ts=ts,
-                sentiment=float(payload.get("sentiment", 0.0)) if payload.get("sentiment") is not None else None,
-                meta=meta,
+                kind=str(payload.get("kind", "headline")),
+                title=str(payload.get("headline", "")),
+                source=str(payload.get("source", "unknown")),
+                url=str(payload.get("url", "")),
+                sentiment_score=_safe_float(payload.get("sentiment") or payload.get("sentiment_score")),
+                importance=_safe_float(payload.get("importance")),
+                dedupe_key=str(payload.get("dedupe_key") or f"{payload['symbol'].upper()}_{ts}"),
+                raw_json={**payload, "fresh": fresh},
             )
         )
 
-    if news_items:
-        db.write_news(news_items)
-    return news_items
+    return catalysts
+
+
+def _safe_float(value: object) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/DayTrading/intraday/data/ibkr_feed.py
+++ b/DayTrading/intraday/data/ibkr_feed.py
@@ -20,9 +20,7 @@ class IBKRFeed:
 
     def collect_bars(self, symbols: Iterable[str], tf: str) -> List[models.Bar]:
         if self.settings.is_simulation:
-            bars = self._generate_sim_bars(symbols, tf)
-            self.db.write_bars(bars)
-            return bars
+            return self._generate_sim_bars(symbols, tf)
 
         logger.warning(
             "IBKR live collection is disabled in this environment; returning an empty result for %s",
@@ -62,6 +60,7 @@ class IBKRFeed:
                         l=round(low_px, 2),
                         c=round(close_px, 2),
                         v=float(volume),
+                        vwap=round((open_px + high_px + low_px + close_px) / 4, 2),
                     )
                 )
         bars.sort(key=lambda b: (b.symbol, b.ts))

--- a/DayTrading/intraday/exec/trade_manager.py
+++ b/DayTrading/intraday/exec/trade_manager.py
@@ -28,10 +28,15 @@ class TradeManager:
         self.account_equity = 100_000.0
         self.positions: Dict[str, ManagedPosition] = {}
 
-    def execute(self, ranked: Iterable, features: Dict[str, Dict[str, float]]) -> List[int]:
+    def execute(
+        self,
+        ranked: Iterable,
+        features: Dict[str, Dict[str, object]],
+        run_date: str,
+    ) -> List[int]:
         trade_ids: List[int] = []
         for signal in ranked:
-            if signal.gate == "VETO":
+            if getattr(signal, "decision", "observe") != "enter_long":
                 continue
             if signal.symbol in self.positions:
                 continue
@@ -45,41 +50,79 @@ class TradeManager:
             qty = self._position_size(price, stop_px)
             if qty <= 0:
                 continue
-            order = self.order_client.submit_order(signal.symbol, "BUY", qty, price)
-            if order["status"] != "FILLED":
+
+            order_response = self.order_client.submit_order(signal.symbol, "BUY", qty, price)
+            if order_response["status"] != "FILLED":
                 continue
-            fill_price = order["avg_fill_price"]
-            trade = models.Trade(
+
+            entry_ts = to_epoch_seconds(now_et())
+            fill_price = float(order_response["avg_fill_price"])
+            order = models.Order(
                 symbol=signal.symbol,
-                side="BUY",
+                side="buy",
+                order_type="market",
                 qty=qty,
-                status="OPEN",
-                entry_px=fill_price,
-                opened_ts=to_epoch_seconds(now_et()),
-                stop_px=stop_px,
-                trail_mode=self.settings.stop_mode,
-                tags=",".join(signal.reasons[:3]),
+                limit_price=None,
+                stop_price=stop_px,
+                tif="DAY",
+                status="filled",
+                placed_ts=entry_ts,
+                updated_ts=entry_ts,
+                meta={"reasons": signal.reasons[:3], "run_date": run_date},
+                client_order_id=f"{signal.symbol}-{entry_ts}",
+                signal_id=None,
             )
-            trade_id = self.db.write_trade(trade)
+            order_id = self.db.insert_order(order)
+            self.db.insert_fill(
+                models.Fill(
+                    order_id=order_id,
+                    fill_ts=entry_ts,
+                    fill_price=fill_price,
+                    fill_qty=qty,
+                    liquidity="added",
+                    venue="SIM" if self.settings.is_simulation else "IBKR",
+                )
+            )
+
+            position_meta = {
+                "stop_px": stop_px,
+                "trail_mode": self.settings.stop_mode,
+                "scale_target": fill_price * (1 + self.settings.scale1_pct / 100),
+                "final_target": fill_price * (1 + self.settings.target_pct / 100),
+                "run_date": run_date,
+            }
             position = models.Position(
                 symbol=signal.symbol,
+                avg_price=fill_price,
                 qty=qty,
-                avg_px=fill_price,
-                opened_ts=trade.opened_ts or 0,
-                stop_px=stop_px,
-                trail_mode=self.settings.stop_mode,
-                meta={
-                    "scale_target": fill_price * (1 + self.settings.scale1_pct / 100),
-                    "final_target": fill_price * (1 + self.settings.target_pct / 100),
-                },
+                opened_ts=entry_ts,
+                last_update_ts=entry_ts,
+                meta=position_meta,
             )
             self.db.upsert_position(position)
+
+            trade_entry = models.TradeJournalEntry(
+                symbol=signal.symbol,
+                open_ts=entry_ts,
+                close_ts=None,
+                side="long",
+                entry_price=fill_price,
+                exit_price=None,
+                qty=qty,
+                pnl=None,
+                reason_open=";".join(signal.reasons[:3]),
+                reason_close=None,
+                tags="|".join(signal.reasons[:3]),
+                signal_id=None,
+            )
+            trade_id = self.db.insert_trade_journal(trade_entry)
+
             self.positions[signal.symbol] = ManagedPosition(trade_id=trade_id, position=position)
             trade_ids.append(trade_id)
             logger.info("Opened position %s size %.0f @ %.2f", signal.symbol, qty, fill_price)
         return trade_ids
 
-    def manage_open_positions(self, features: Dict[str, Dict[str, float]]) -> None:
+    def manage_open_positions(self, features: Dict[str, Dict[str, object]]) -> None:
         for symbol, managed in list(self.positions.items()):
             row = features.get(symbol)
             if not row:
@@ -87,10 +130,12 @@ class TradeManager:
             price = float(row.get("c", 0.0))
             ema_trail = float(row.get("ema_slow", price))
             position = managed.position
-            scale_target = position.meta.get("scale_target", price)
-            final_target = position.meta.get("final_target", price)
+            meta = position.meta or {}
+            scale_target = float(meta.get("scale_target", price))
+            final_target = float(meta.get("final_target", price))
+            stop_px = float(meta.get("stop_px", 0.0))
 
-            if price <= (position.stop_px or 0):
+            if price <= stop_px:
                 self._close_position(symbol, price, reason="stop hit")
                 continue
 
@@ -99,9 +144,11 @@ class TradeManager:
                 self.order_client.submit_order(symbol, "SELL", scaled_qty, price)
                 position.qty -= scaled_qty
                 managed.scaled = True
-                position.stop_px = max(position.stop_px or 0, ema_trail)
+                stop_px = max(stop_px, ema_trail)
+                meta.update({"qty": position.qty, "stop_px": stop_px})
+                position.meta = meta
+                position.last_update_ts = to_epoch_seconds(now_et())
                 self.db.upsert_position(position)
-                self.db.log_metric("scale", to_epoch_seconds(now_et()), scaled_qty, {"symbol": symbol})
                 logger.info("Scaled position %s to %.0f shares", symbol, position.qty)
                 continue
 
@@ -109,11 +156,13 @@ class TradeManager:
                 self._close_position(symbol, price, reason="target hit")
                 continue
 
-            if ema_trail > (position.stop_px or 0):
-                position.stop_px = ema_trail
+            if ema_trail > stop_px:
+                meta["stop_px"] = ema_trail
+                position.meta = meta
+                position.last_update_ts = to_epoch_seconds(now_et())
                 self.db.upsert_position(position)
 
-    def flatten_all(self, features: Dict[str, Dict[str, float]]) -> None:
+    def flatten_all(self, features: Dict[str, Dict[str, object]]) -> None:
         for symbol in list(self.positions.keys()):
             price = float(features.get(symbol, {}).get("c", 0.0))
             self._close_position(symbol, price, reason="flatten")
@@ -129,15 +178,44 @@ class TradeManager:
         if not managed:
             return
         position = managed.position
-        self.order_client.submit_order(symbol, "SELL", position.qty, price)
-        trade_id = managed.trade_id
-        pnl = (price - (position.avg_px or 0.0)) * position.qty
-        self.db.update_trade(
-            trade_id,
-            status="CLOSED",
-            exit_px=price,
-            closed_ts=to_epoch_seconds(now_et()),
-            pnl=pnl,
+        qty = position.qty
+        self.order_client.submit_order(symbol, "SELL", qty, price)
+        exit_ts = to_epoch_seconds(now_et())
+        order = models.Order(
+            symbol=symbol,
+            side="sell",
+            order_type="market",
+            qty=qty,
+            limit_price=None,
+            stop_price=None,
+            tif="DAY",
+            status="filled",
+            placed_ts=exit_ts,
+            updated_ts=exit_ts,
+            meta={"reason": reason},
+            client_order_id=f"{symbol}-close-{exit_ts}",
+            signal_id=None,
         )
-        self.db.execute("DELETE FROM positions WHERE symbol = ?", (symbol,))
+        order_id = self.db.insert_order(order)
+        self.db.insert_fill(
+            models.Fill(
+                order_id=order_id,
+                fill_ts=exit_ts,
+                fill_price=price,
+                fill_qty=qty,
+                liquidity="added",
+                venue="SIM" if self.settings.is_simulation else "IBKR",
+            )
+        )
+
+        pnl = (price - position.avg_price) * qty
+        self.db.update_trade_journal(
+            managed.trade_id,
+            close_ts=exit_ts,
+            exit_price=price,
+            qty=qty,
+            pnl=pnl,
+            reason_close=reason,
+        )
+        self.db.delete_position(symbol)
         logger.info("Closed position %s (%s) @ %.2f", symbol, reason, price)

--- a/DayTrading/intraday/orchestrator.py
+++ b/DayTrading/intraday/orchestrator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from .ai.sentiment import SentimentAnalyzer
 from .ai.regime import current_regime
@@ -13,19 +13,21 @@ from .data.ibkr_feed import IBKRFeed
 from .data.yahoo_feed import YahooFeed
 from .exec.order_client import OrderClient
 from .exec.trade_manager import TradeManager
-from .ingestion.watchlist_loader import WatchlistLoader
+from .ingestion.watchlist_loader import FocusList, WatchlistLoader
 from .market_clock import should_flatten
 from .settings import AppSettings
+from .storage import models
 from .storage.db import Database
 from .strategy import engine, features
-from .utils.time import now_et
+from .utils.time import now_et, to_epoch_seconds
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class CycleArtifacts:
-    run_id: int
+    cycle_id: int
+    run_date: str
     ranked: List[engine.RankedSignal]
     trades: List[int]
 
@@ -41,44 +43,127 @@ class Orchestrator:
         self.sentiment = SentimentAnalyzer(settings, db)
         self.order_client = OrderClient(settings, db)
         self.trade_manager = TradeManager(settings, db, self.order_client)
-        self._last_watchlist: Tuple[int, List[str], Dict[str, Dict[str, object]]] | None = None
+        self._last_watchlist: FocusList | None = None
 
-    def load_or_import_watchlist(self) -> Tuple[int, List[str], Dict[str, Dict[str, object]]]:
+    def load_or_import_watchlist(self) -> FocusList:
         if self._last_watchlist is None:
             self._last_watchlist = self.loader.load()
         return self._last_watchlist
 
-    def collect_bars(self, symbols: List[str]) -> List:
-        bars_5m = self.ibkr.collect_bars(symbols, "5m")
-        self.ibkr.collect_bars(symbols, "15m")
-        return bars_5m
+    def collect_bars(self, focus: FocusList, timeframe: str) -> List:
+        bars = self.ibkr.collect_bars(focus.symbols, timeframe)
+        source = "SIM" if self.settings.is_simulation else "IBKR"
+        self.db.write_intraday_bars(bars, timeframe, source, focus.run_date)
+        return bars
 
-    def collect_catalysts(self, symbols: List[str]) -> List:
+    def collect_catalysts(self, symbols: List[str]) -> List[models.Catalyst]:
         finnhub_items = self.finnhub.fetch(symbols)
         yahoo_items = self.yahoo.fetch(symbols) if self.settings.yahoo_rss_enabled else []
-        return merge_catalysts(self.db, self.settings.catalyst_fresh_hours, finnhub_items, yahoo_items)
+        return merge_catalysts(self.settings.catalyst_fresh_hours, finnhub_items, yahoo_items)
 
     def run_cycle(self, timeframe: str) -> CycleArtifacts:
         logger.info("Starting cycle for %s", timeframe)
-        run_id, symbols, ctx_map = self.load_or_import_watchlist()
-        bars = self.collect_bars(symbols)
-        feature_map = features.build_snapshot(bars, ctx_map, self.settings)
-        catalysts = self.collect_catalysts(symbols)
+        focus = self.load_or_import_watchlist()
+        start_ts = to_epoch_seconds(now_et())
+        cycle_id = self.db.insert_intraday_cycle_run(
+            models.IntradayCycleRun(
+                run_started_ts=start_ts,
+                run_finished_ts=None,
+                watchlist_count=len(focus.symbols),
+                evaluated_count=0,
+                placed_orders=0,
+                errors_count=0,
+                timings=None,
+                notes={"timeframe": timeframe, "run_date": focus.run_date},
+            )
+        )
+
+        bars = self.collect_bars(focus, timeframe)
+        feature_map = features.build_snapshot(bars, focus.context, self.settings)
+        feature_rows = self._persist_features(timeframe, bars, feature_map)
+
+        catalysts = self.collect_catalysts(focus.symbols)
+        self.db.write_catalysts(catalysts)
+
         sentiment_results = self.sentiment.analyze(catalysts)
         ranked = engine.rank_candidates(feature_map, sentiment_results, self.settings)
         regime = current_regime()
         for signal in ranked:
             signal.score *= regime.multiplier
-        trades = self.trade_manager.execute(ranked, feature_map)
+        self._persist_signals(focus, timeframe, ranked, feature_rows)
+        trades = self.trade_manager.execute(ranked, feature_map, focus.run_date)
         self.trade_manager.manage_open_positions(feature_map)
         if ranked:
             top = ranked[0]
             pushover.send(self.settings, "Top Candidate", f"{top.symbol} score {top.score:.1f}")
-        return CycleArtifacts(run_id=run_id, ranked=ranked, trades=trades)
+        finished_ts = to_epoch_seconds(now_et())
+        self.db.update_intraday_cycle_run(
+            cycle_id,
+            run_finished_ts=finished_ts,
+            evaluated_count=len(feature_rows),
+            placed_orders=len(trades),
+        )
+        return CycleArtifacts(cycle_id=cycle_id, run_date=focus.run_date, ranked=ranked, trades=trades)
 
     def flatten_guard(self) -> None:
         if should_flatten(self.settings.flatten_dt_today, now_et()):
-            run_id, symbols, ctx_map = self.load_or_import_watchlist()
-            bars = self.collect_bars(symbols)
-            feature_map = features.build_snapshot(bars, ctx_map, self.settings)
+            focus = self.load_or_import_watchlist()
+            bars = self.collect_bars(focus, "5m")
+            feature_map = features.build_snapshot(bars, focus.context, self.settings)
             self.trade_manager.flatten_all(feature_map)
+
+    def _persist_features(
+        self,
+        timeframe: str,
+        bars: List[models.Bar],
+        feature_map: Dict[str, Dict[str, object]],
+    ) -> List[models.IntradayFeatureRow]:
+        latest_ts: Dict[str, int] = {}
+        for bar in bars:
+            latest_ts[bar.symbol] = max(bar.ts, latest_ts.get(bar.symbol, 0))
+
+        rows: List[models.IntradayFeatureRow] = []
+        for symbol, data in feature_map.items():
+            ts = latest_ts.get(symbol)
+            if ts is None:
+                continue
+            rows.append(
+                models.IntradayFeatureRow(
+                    symbol=symbol,
+                    ts=ts,
+                    timeframe=timeframe,
+                    features=data,
+                )
+            )
+        self.db.write_intraday_features(rows)
+        return rows
+
+    def _persist_signals(
+        self,
+        focus: FocusList,
+        timeframe: str,
+        ranked: List[engine.RankedSignal],
+        feature_rows: List[models.IntradayFeatureRow],
+    ) -> None:
+        ts_map = {row.symbol: row.ts for row in feature_rows}
+        records = []
+        for signal in ranked:
+            ts = ts_map.get(signal.symbol)
+            if ts is None:
+                continue
+            records.append(
+                models.SignalRecord(
+                    symbol=signal.symbol,
+                    ts=ts,
+                    timeframe=timeframe,
+                    base_score=signal.base_score,
+                    ai_adjustment=signal.ai_adjustment,
+                    final_score=signal.score,
+                    decision=signal.decision,
+                    reason_tags="|".join(signal.reasons),
+                    details={"reasons": signal.reasons},
+                    phase1_rank=focus.ranks.get(signal.symbol),
+                    run_date=focus.run_date,
+                )
+            )
+        self.db.write_signals(records)

--- a/DayTrading/intraday/settings.py
+++ b/DayTrading/intraday/settings.py
@@ -16,8 +16,9 @@ class AppSettings:
     tz: str = "America/Toronto"
     simulation: bool = True
     watchlist_db_path: str | None = None
+    focus_run_date: str | None = None
     watchlist_symbol_key: str = "symbol"
-    sqlite_path: str = "var/daytrading.db"
+    sqlite_path: str = "premarket.db"
     ema_fast: int = 9
     ema_slow: int = 21
     vol_spike_mult: float = 2.0
@@ -50,9 +51,18 @@ class AppSettings:
 
         self.tz = env("TZ", self.tz)
         self.simulation = env("SIMULATION", str(self.simulation)).lower() == "true"
-        self.watchlist_db_path = env("WATCHLIST_DB_PATH", self.watchlist_db_path)
-        self.watchlist_symbol_key = env("WATCHLIST_SYMBOL_KEY", self.watchlist_symbol_key)
         self.sqlite_path = env("SQLITE_PATH", self.sqlite_path)
+        self.watchlist_db_path = env(
+            "WATCHLIST_DB_PATH", self.watchlist_db_path or self.sqlite_path
+        )
+        self.watchlist_symbol_key = env("WATCHLIST_SYMBOL_KEY", self.watchlist_symbol_key)
+        self.focus_run_date = env("FOCUS_RUN_DATE", self.focus_run_date)
+
+        if self.focus_run_date:
+            try:
+                datetime.fromisoformat(self.focus_run_date)
+            except ValueError as exc:  # pragma: no cover - guard clause
+                raise ValueError("FOCUS_RUN_DATE must be YYYY-MM-DD") from exc
 
         self.ema_fast = int(env("EMA_FAST", str(self.ema_fast)))
         self.ema_slow = int(env("EMA_SLOW", str(self.ema_slow)))

--- a/DayTrading/intraday/storage/models.py
+++ b/DayTrading/intraday/storage/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping, Sequence
 
 
 @dataclass(slots=True)
@@ -14,42 +14,120 @@ class Bar:
     l: float
     c: float
     v: float
+    vwap: float | None = None
 
 
 @dataclass(slots=True)
-class NewsItem:
+class Catalyst:
     symbol: str
-    source: str
-    headline: str
-    url: str
     ts: int
-    sentiment: float | None = None
-    meta: Dict[str, Any] | None = None
+    kind: str
+    title: str
+    source: str
+    url: str | None = None
+    sentiment_score: float | None = None
+    importance: float | None = None
+    dedupe_key: str | None = None
+    raw_json: Mapping[str, Any] | None = None
 
 
 @dataclass(slots=True)
-class Trade:
+class IntradayFeatureRow:
+    symbol: str
+    ts: int
+    timeframe: str
+    features: Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class SignalRecord:
+    symbol: str
+    ts: int
+    timeframe: str
+    base_score: float
+    ai_adjustment: float
+    final_score: float
+    decision: str
+    reason_tags: str
+    details: Mapping[str, Any]
+    phase1_rank: int | None = None
+    run_date: str | None = None
+
+
+@dataclass(slots=True)
+class AIProvenanceRecord:
+    symbol: str
+    ts: int
+    model_name: str
+    inputs: Mapping[str, Any] | None
+    outputs: Mapping[str, Any] | None
+    delta_applied: float | None
+    notes: str | None = None
+
+
+@dataclass(slots=True)
+class Order:
     symbol: str
     side: str
+    order_type: str
     qty: float
+    limit_price: float | None
+    stop_price: float | None
+    tif: str
     status: str
-    entry_px: float | None = None
-    exit_px: float | None = None
-    opened_ts: int | None = None
-    closed_ts: int | None = None
-    stop_px: float | None = None
-    trail_mode: str | None = None
-    tags: str | None = None
-    pnl: float | None = None
-    meta: Dict[str, Any] | None = None
+    placed_ts: int
+    updated_ts: int | None
+    meta: Mapping[str, Any] | None = None
+    client_order_id: str | None = None
+    signal_id: int | None = None
+
+
+@dataclass(slots=True)
+class Fill:
+    order_id: int
+    fill_ts: int
+    fill_price: float
+    fill_qty: float
+    liquidity: str | None = None
+    venue: str | None = None
 
 
 @dataclass(slots=True)
 class Position:
     symbol: str
+    avg_price: float
     qty: float
-    avg_px: float
     opened_ts: int
-    stop_px: float | None = None
-    trail_mode: str | None = None
+    last_update_ts: int
     meta: Dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class TradeJournalEntry:
+    symbol: str
+    open_ts: int
+    close_ts: int | None
+    side: str
+    entry_price: float
+    exit_price: float | None
+    qty: float
+    pnl: float | None
+    reason_open: str | None
+    reason_close: str | None
+    tags: str | None
+    signal_id: int | None = None
+
+
+@dataclass(slots=True)
+class IntradayCycleRun:
+    run_started_ts: int
+    run_finished_ts: int | None
+    watchlist_count: int
+    evaluated_count: int
+    placed_orders: int
+    errors_count: int
+    timings: Mapping[str, float] | None = None
+    notes: Mapping[str, Any] | None = None
+
+
+PayloadSequence = Iterable[Sequence[Any]]

--- a/DayTrading/intraday/storage/schema.py
+++ b/DayTrading/intraday/storage/schema.py
@@ -1,0 +1,202 @@
+"""Shared Phase 2 schema definition for runtime upgrades."""
+
+from __future__ import annotations
+
+PHASE2_SCHEMA = """
+BEGIN IMMEDIATE;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS bars_intraday (
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  open REAL NOT NULL,
+  high REAL NOT NULL,
+  low REAL NOT NULL,
+  close REAL NOT NULL,
+  volume REAL NOT NULL,
+  vwap REAL,
+  source TEXT DEFAULT 'IBKR',
+  run_date TEXT,
+  PRIMARY KEY (symbol, timeframe, ts)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bars_intraday_symbol_tf_ts
+  ON bars_intraday(symbol, timeframe, ts);
+
+CREATE TABLE IF NOT EXISTS catalysts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  title TEXT,
+  source TEXT,
+  url TEXT,
+  raw_json TEXT,
+  dedupe_key TEXT,
+  sentiment_score REAL,
+  importance REAL,
+  UNIQUE(symbol, ts, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_catalysts_symbol_ts
+  ON catalysts(symbol, ts DESC);
+
+CREATE TABLE IF NOT EXISTS intraday_features (
+  symbol TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  features_json TEXT NOT NULL,
+  PRIMARY KEY (symbol, ts, timeframe)
+);
+
+CREATE INDEX IF NOT EXISTS idx_intraday_features_symbol_ts
+  ON intraday_features(symbol, ts);
+
+CREATE TABLE IF NOT EXISTS signals (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  base_score REAL NOT NULL,
+  ai_adjustment REAL DEFAULT 0.0,
+  final_score REAL NOT NULL,
+  decision TEXT NOT NULL,
+  reason_tags TEXT,
+  details_json TEXT,
+  phase1_rank INTEGER,
+  run_date TEXT,
+  UNIQUE(symbol, ts, timeframe)
+);
+
+CREATE INDEX IF NOT EXISTS idx_signals_rank_score
+  ON signals(final_score DESC, ts DESC);
+
+CREATE TABLE IF NOT EXISTS ai_provenance (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  ts TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  inputs_json TEXT,
+  outputs_json TEXT,
+  delta_applied REAL,
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_prov_symbol_ts
+  ON ai_provenance(symbol, ts);
+
+CREATE TABLE IF NOT EXISTS orders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  client_order_id TEXT UNIQUE,
+  symbol TEXT NOT NULL,
+  side TEXT NOT NULL CHECK (side IN ('buy','sell')),
+  order_type TEXT NOT NULL CHECK (order_type IN ('limit','market','stop','stop_limit')),
+  qty REAL NOT NULL,
+  limit_price REAL,
+  stop_price REAL,
+  tif TEXT DEFAULT 'DAY',
+  status TEXT NOT NULL DEFAULT 'new'
+         CHECK (status IN ('new','submitted','partially_filled','filled','canceled','rejected')),
+  placed_ts TEXT NOT NULL,
+  updated_ts TEXT,
+  meta_json TEXT,
+  signal_id INTEGER,
+  FOREIGN KEY (signal_id) REFERENCES signals(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orders_symbol_status
+  ON orders(symbol, status);
+
+CREATE TABLE IF NOT EXISTS fills (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  order_id INTEGER NOT NULL,
+  fill_ts TEXT NOT NULL,
+  fill_price REAL NOT NULL,
+  fill_qty REAL NOT NULL,
+  liquidity TEXT,
+  venue TEXT,
+  FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_fills_order ON fills(order_id);
+
+CREATE TABLE IF NOT EXISTS positions (
+  symbol TEXT PRIMARY KEY,
+  avg_price REAL NOT NULL,
+  qty REAL NOT NULL,
+  opened_ts TEXT NOT NULL,
+  last_update_ts TEXT NOT NULL,
+  meta_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS trade_journal (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  open_ts TEXT NOT NULL,
+  close_ts TEXT,
+  side TEXT CHECK (side IN ('long','short')),
+  entry_price REAL,
+  exit_price REAL,
+  qty REAL,
+  pnl REAL,
+  pnl_pct REAL,
+  max_fav_excursion REAL,
+  max_adv_excursion REAL,
+  reason_open TEXT,
+  reason_close TEXT,
+  tags TEXT,
+  signal_id INTEGER,
+  FOREIGN KEY (signal_id) REFERENCES signals(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_trades_symbol_time
+  ON trade_journal(symbol, open_ts);
+
+CREATE TABLE IF NOT EXISTS intraday_cycle_run (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_started_ts TEXT NOT NULL,
+  run_finished_ts TEXT,
+  watchlist_count INTEGER,
+  evaluated_count INTEGER,
+  placed_orders INTEGER,
+  errors_count INTEGER,
+  timings_json TEXT,
+  notes_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS app_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  level TEXT NOT NULL CHECK (level IN ('DEBUG','INFO','WARN','ERROR')),
+  scope TEXT,
+  message TEXT NOT NULL,
+  context_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_events_ts ON app_events(ts);
+
+CREATE VIEW IF NOT EXISTS v_focus_symbols AS
+SELECT
+  w.run_date,
+  w.symbol,
+  w.rank,
+  w.score AS premarket_score,
+  w.tier,
+  (SELECT s.ts FROM signals s WHERE s.symbol = w.symbol ORDER BY s.ts DESC LIMIT 1) AS last_signal_ts,
+  (SELECT s.final_score FROM signals s WHERE s.symbol = w.symbol ORDER BY s.ts DESC LIMIT 1) AS last_final_score,
+  (SELECT s.decision FROM signals s WHERE s.symbol = w.symbol ORDER BY s.ts DESC LIMIT 1) AS last_decision
+FROM watchlist w;
+
+CREATE VIEW IF NOT EXISTS v_latest_bars AS
+SELECT b.symbol, b.timeframe, b.ts, b.open, b.high, b.low, b.close, b.volume, b.vwap
+FROM bars_intraday b
+JOIN (
+  SELECT symbol, timeframe, MAX(ts) AS max_ts
+  FROM bars_intraday
+  GROUP BY symbol, timeframe
+) t ON b.symbol = t.symbol AND b.timeframe = t.timeframe AND b.ts = t.max_ts;
+
+COMMIT;
+"""
+

--- a/DayTrading/intraday/strategy/features.py
+++ b/DayTrading/intraday/strategy/features.py
@@ -7,7 +7,11 @@ from ..storage import models
 from . import indicators
 
 
-def build_snapshot(bars: Iterable[models.Bar], context: Dict[str, Dict[str, object]], settings: AppSettings) -> Dict[str, Dict[str, float]]:
+def build_snapshot(
+    bars: Iterable[models.Bar],
+    context: Dict[str, Dict[str, object]],
+    settings: AppSettings,
+) -> Dict[str, Dict[str, object]]:
     grouped: Dict[str, List[models.Bar]] = {}
     for bar in bars:
         grouped.setdefault(bar.symbol, []).append(bar)

--- a/DayTrading/intraday/utils/time.py
+++ b/DayTrading/intraday/utils/time.py
@@ -25,3 +25,8 @@ def minutes_until(target: datetime) -> int:
 
 def hours_ago(hours: float) -> datetime:
     return now_et() - timedelta(hours=hours)
+
+
+def today_et() -> datetime:
+    now = now_et()
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/DayTrading/main.py
+++ b/DayTrading/main.py
@@ -22,8 +22,7 @@ def setup() -> tuple[AppSettings, Database, Orchestrator]:
     Path("logs").mkdir(exist_ok=True)
     configure_logging(settings.log_cfg)
     db = Database(Path(settings.sqlite_path))
-    migrations_dir = Path(__file__).parent / "intraday" / "storage" / "migrations"
-    db.run_migrations(migrations_dir)
+    db.run_migrations()
     orchestrator = Orchestrator(settings, db)
     return settings, db, orchestrator
 

--- a/DayTrading/scripts/import_watchlist.py
+++ b/DayTrading/scripts/import_watchlist.py
@@ -15,10 +15,9 @@ app = typer.Typer()
 def main(path: Path = typer.Option(..., exists=True, readable=True)) -> None:
     settings = AppSettings()
     db = Database(Path(settings.sqlite_path))
-    migrations = Path(__file__).parent.parent / "intraday" / "storage" / "migrations"
-    db.run_migrations(migrations)
-    run_id, symbols, _ = load_watchlist(settings, db, path)
-    typer.echo(f"Imported run {run_id} with {len(symbols)} symbols")
+    db.run_migrations()
+    focus = load_watchlist(settings, db, path)
+    typer.echo(f"Imported {len(focus.symbols)} symbols for {focus.run_date}")
 
 
 if __name__ == "__main__":

--- a/DayTrading/scripts/upgrade_phase2_schema.py
+++ b/DayTrading/scripts/upgrade_phase2_schema.py
@@ -1,0 +1,125 @@
+"""Schema upgrade script to apply Phase 2 tables and views to ``premarket.db``.
+
+The Phase 2 upgrade introduces the following data structures while preserving the
+Phase 1 outputs (``full_watchlist``, ``top_n``, ``watchlist``, ``run_summary``)
+that downstream tools already rely on:
+
+- ``bars_intraday``: Stores intraday OHLCV bars and derived metrics for a
+  symbol/timeframe pair so that live scoring has a canonical price history.
+- ``catalysts``: Tracks qualitative catalysts such as news headlines along with
+  metadata, sentiment, and dedupe keys used during intraday decisioning.
+- ``intraday_features``: Persists serialized feature vectors generated during
+  intraday analysis runs; these extend the engineered ``features_json`` that
+  Phase 1 emits in ``full_watchlist`` so AI models can rescore symbols quickly.
+- ``signals``: Records algorithmic trade signals, including AI adjustments,
+  provenance metadata, and links back to the Phase 1 ranking (``phase1_rank``).
+- ``ai_provenance``: Captures supporting model I/O that influenced
+  AI-driven adjustments to signals for compliance and debugging.
+- ``orders``: Maintains broker order submissions and status changes tied back
+  to originating signals.
+- ``fills``: Logs order execution fills received from the broker with
+  price/venue information.
+- ``positions``: Represents the current live position book including quantity
+  and cost basis per symbol.
+- ``trade_journal``: Archives completed or in-flight trades for post-trade
+  analysis, linking back to ``signals`` to maintain a full audit trail.
+- ``intraday_cycle_run``: Summarizes each intraday automation cycle with
+  timing diagnostics so the ``run_summary`` audit trail stays consistent across
+  phases.
+- ``app_events``: Stores structured application logs for observability and
+  troubleshooting during automated runs.
+- ``v_focus_symbols``: View exposing the current focus list by selecting
+  ranked symbols from ``watchlist``/``top_n`` and annotating them with the most
+  recent Phase 2 signal metadata.
+- ``v_latest_bars``: View surfacing the freshest intraday bar per
+  symbol/timeframe combination for quick lookups.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from DayTrading.intraday.storage.schema import PHASE2_SCHEMA
+
+def upgrade_schema(db_path: str = "premarket.db") -> None:
+    """Apply the Phase 2 schema extension to the specified SQLite database.
+
+    The upgrade enables foreign key enforcement and executes the Phase 2 DDL
+    within a transaction so it can safely run multiple times without disrupting
+    Phase 1 tables or views.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys=ON;")
+        conn.executescript(PHASE2_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    print("Phase 2 schema applied successfully to", db_path)
+
+
+if __name__ == "__main__":
+    upgrade_schema()
+
+    # --- Usage examples ---
+    with sqlite3.connect("premarket.db") as conn:
+        conn.execute("PRAGMA foreign_keys=ON;")
+        cur = conn.cursor()
+
+        # Insert a new 5m bar sourced from the live market feed.
+        cur.execute(
+            """
+            INSERT OR REPLACE INTO bars_intraday
+            (symbol,timeframe,ts,open,high,low,close,volume,vwap)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            ("NVDA", "5m", "2025-10-03T14:30:00Z", 450.0, 455.0, 448.0, 454.5, 1_200_000, 452.0),
+        )
+
+        # Insert a catalyst headline that will influence the focus ranking.
+        cur.execute(
+            """
+            INSERT INTO catalysts (symbol,ts,kind,title,source,url,sentiment_score,importance,dedupe_key)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "NVDA",
+                "2025-10-03T14:35:00Z",
+                "news",
+                "NVIDIA beats earnings",
+                "Yahoo",
+                "https://finance.yahoo.com/nvda",
+                0.8,
+                0.9,
+                "nvda_beat_20251003",
+            ),
+        )
+
+        # Insert a signal with an AI adjustment sourced from intraday features.
+        cur.execute(
+            """
+            INSERT OR REPLACE INTO signals
+            (symbol,ts,timeframe,base_score,ai_adjustment,final_score,decision,reason_tags,details_json)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "NVDA",
+                "2025-10-03T14:40:00Z",
+                "5m",
+                0.65,
+                0.1,
+                0.75,
+                "enter_long",
+                "EMA_cross|Volume_spike",
+                '{"feature_snapshot_id": 123}',
+            ),
+        )
+
+        # Query today's focus list sourced from the Phase 1 watchlist/top_n tables.
+        try:
+            rows = list(cur.execute("SELECT * FROM v_focus_symbols WHERE run_date=date('now');"))
+        except sqlite3.OperationalError as exc:
+            print("Focus list unavailable until Phase 1 tables are populated:", exc)
+        else:
+            for row in rows:
+                print(row)

--- a/DayTrading/tests/conftest.py
+++ b/DayTrading/tests/conftest.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import json
 import os
+import json
+import os
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Iterator
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from intraday.orchestrator import Orchestrator
 from intraday.settings import AppSettings
@@ -25,8 +32,8 @@ def _configure_env(tmp_path: Path) -> Iterator[None]:
 RUN_MODE=once
 SIMULATION=true
 WATCHLIST_DB_PATH={watchlist_db}
-SQLITE_PATH={db}
-""".strip().format(watchlist_db=premarket_db, db=tmp_path / "test.db"),
+SQLITE_PATH={watchlist_db}
+""".strip().format(watchlist_db=premarket_db),
         encoding="utf-8",
     )
     cwd = Path(__file__).resolve().parents[1]
@@ -43,8 +50,7 @@ def settings() -> AppSettings:
 @pytest.fixture
 def db(settings: AppSettings) -> Iterator[Database]:
     db = Database(Path(settings.sqlite_path))
-    migrations = Path(__file__).resolve().parents[1] / "intraday" / "storage" / "migrations"
-    db.run_migrations(migrations)
+    db.run_migrations()
     yield db
     db.close()
 

--- a/DayTrading/tests/test_ai_sentiment.py
+++ b/DayTrading/tests/test_ai_sentiment.py
@@ -8,19 +8,21 @@ from intraday.utils.time import now_et, to_epoch_seconds
 def test_sentiment_heuristic_scores(settings, db):
     analyzer = SentimentAnalyzer(settings, db)
     news = [
-        models.NewsItem(
+        models.Catalyst(
             symbol="AAPL",
-            source="test",
-            headline="Company announces strong upgrade and record growth",
-            url="",
             ts=to_epoch_seconds(now_et()),
+            kind="headline",
+            title="Company announces strong upgrade and record growth",
+            source="test",
+            url="",
         ),
-        models.NewsItem(
+        models.Catalyst(
             symbol="TSLA",
-            source="test",
-            headline="Manufacturer faces lawsuit and weak outlook",
-            url="",
             ts=to_epoch_seconds(now_et()),
+            kind="headline",
+            title="Manufacturer faces lawsuit and weak outlook",
+            source="test",
+            url="",
         ),
     ]
     result = analyzer.analyze(news)

--- a/DayTrading/tests/test_orchestrator_once.py
+++ b/DayTrading/tests/test_orchestrator_once.py
@@ -5,13 +5,15 @@ from intraday.orchestrator import Orchestrator
 
 def test_run_cycle_creates_records(orchestrator: Orchestrator, db):
     artifacts = orchestrator.run_cycle("5m")
-    assert artifacts.run_id > 0
+    assert artifacts.cycle_id > 0
     assert artifacts.ranked
 
-    bars = db.execute("SELECT COUNT(*) as c FROM bars").fetchone()["c"]
-    news = db.execute("SELECT COUNT(*) as c FROM news").fetchone()["c"]
+    bars = db.execute("SELECT COUNT(*) as c FROM bars_intraday").fetchone()["c"]
+    catalysts = db.execute("SELECT COUNT(*) as c FROM catalysts").fetchone()["c"]
     ai = db.execute("SELECT COUNT(*) as c FROM ai_provenance").fetchone()["c"]
+    signals = db.execute("SELECT COUNT(*) as c FROM signals").fetchone()["c"]
 
     assert bars > 0
-    assert news > 0
+    assert catalysts > 0
     assert ai > 0
+    assert signals > 0

--- a/DayTrading/tests/test_watchlist_ingest.py
+++ b/DayTrading/tests/test_watchlist_ingest.py
@@ -3,15 +3,9 @@ from __future__ import annotations
 from intraday.ingestion.watchlist_loader import load_watchlist
 
 
-def test_watchlist_loader_inserts(settings, db):
-    run_id, symbols, context = load_watchlist(settings, db)
-    assert run_id > 0
-    assert symbols == ["AAPL", "MSFT", "TSLA"]
-    assert "AAPL" in context
-    assert "relvol" in context["AAPL"]
-
-    cur = db.execute("SELECT COUNT(*) as c FROM watchlist_items")
-    assert cur.fetchone()["c"] == 3
-
-    run_row = db.execute("SELECT row_count FROM watchlist_runs WHERE id = ?", (run_id,)).fetchone()
-    assert run_row["row_count"] == 3
+def test_watchlist_loader_reads_focus_list(settings, db):
+    focus = load_watchlist(settings, db)
+    assert focus.symbols == ["AAPL", "MSFT", "TSLA"]
+    assert focus.run_date == "2024-04-01"
+    assert "AAPL" in focus.context
+    assert "relvol" in focus.context["AAPL"]


### PR DESCRIPTION
## Summary
- add a shared Phase 2 schema module and have the runtime migrator and upgrade script execute it
- update database, orchestration, ingestion, and trade management layers to persist bars, catalysts, features, signals, and trades into the new Phase 2 tables while reading focus symbols from the Phase 1 watchlist
- revise simulation data feeds, AI sentiment logging, and tests to exercise the new workflow end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df4e058ba48331a08b004f8ba893f8